### PR TITLE
fix: reduce max rounds to 3 and prevent duplicate questions

### DIFF
--- a/components/inventory/add-item-dialog.tsx
+++ b/components/inventory/add-item-dialog.tsx
@@ -781,7 +781,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
       }
 
       // Case 2: More questions and under round limit - ask again
-      if (result.questions && result.questions.length > 0 && nextRound < 5) {
+      if (result.questions && result.questions.length > 0 && nextRound < 3) {
         setPendingResult(result)
         setClarificationNeeded(true)
         setStructuredAnswers({}) // Reset for new questions
@@ -809,7 +809,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
       setPendingResult(null)
 
       toast({
-        title: nextRound >= 5 ? "Max rounds reached" : "Item analyzed",
+        title: nextRound >= 3 ? "Max rounds reached" : "Item analyzed",
         description: "Using visual estimates. You can refine the details below.",
       })
     } catch (error) {
@@ -1044,7 +1044,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                       </h4>
                       <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
                         Strategy: {pendingResult.strategy.approach.replace(/_/g, " ")}
-                        {clarificationRound > 0 && ` (Round ${clarificationRound + 1}/5)`}
+                        {clarificationRound > 0 && ` (Round ${clarificationRound + 1}/3)`}
                       </p>
                     </div>
 

--- a/lib/prompts/photo-identification/strategic.test.ts
+++ b/lib/prompts/photo-identification/strategic.test.ts
@@ -87,16 +87,14 @@ describe("strategic prompt", () => {
       expect(prompt).not.toContain("NO MORE QUESTIONS ALLOWED");
     });
 
-    it("does not include final round warning for rounds 1-3", () => {
-      for (const round of [1, 2, 3]) {
-        const prompt = buildPrompt({ clarificationRound: round });
-        expect(prompt).not.toContain("FINAL ROUND");
-        expect(prompt).not.toContain("NO MORE QUESTIONS ALLOWED");
-      }
+    it("does not include final round warning for round 1", () => {
+      const prompt = buildPrompt({ clarificationRound: 1 });
+      expect(prompt).not.toContain("FINAL ROUND");
+      expect(prompt).not.toContain("NO MORE QUESTIONS ALLOWED");
     });
 
-    it("includes final round warning when clarificationRound is 4", () => {
-      const prompt = buildPrompt({ clarificationRound: 4 });
+    it("includes final round warning when clarificationRound is 2", () => {
+      const prompt = buildPrompt({ clarificationRound: 2 });
 
       expect(prompt).toContain("FINAL ROUND");
       expect(prompt).toContain("NO MORE QUESTIONS ALLOWED");
@@ -104,8 +102,8 @@ describe("strategic prompt", () => {
       expect(prompt).toContain("return an empty questions array");
     });
 
-    it("includes final round warning when clarificationRound is >= 4", () => {
-      const prompt = buildPrompt({ clarificationRound: 5 });
+    it("includes final round warning when clarificationRound is >= 2", () => {
+      const prompt = buildPrompt({ clarificationRound: 3 });
 
       expect(prompt).toContain("FINAL ROUND");
       expect(prompt).toContain("NO MORE QUESTIONS ALLOWED");
@@ -113,7 +111,7 @@ describe("strategic prompt", () => {
 
     it("includes final round warning with previous answers", () => {
       const prompt = buildPrompt({
-        clarificationRound: 4,
+        clarificationRound: 2,
         previousAnswers: { "Where purchased?": "IKEA" },
       });
 
@@ -131,6 +129,13 @@ describe("strategic prompt", () => {
       expect(prompt).toContain("store_search");
       expect(prompt).toContain("feature_match");
       expect(prompt).toContain("use_estimates");
+    });
+
+    it("includes rule to never repeat questions", () => {
+      const prompt = buildPrompt({});
+
+      expect(prompt).toContain("NEVER repeat questions");
+      expect(prompt).toContain("PREVIOUS ANSWERS");
     });
 
     it("includes available categories", () => {

--- a/lib/prompts/photo-identification/strategic.ts
+++ b/lib/prompts/photo-identification/strategic.ts
@@ -57,7 +57,7 @@ export const buildPrompt: PromptBuilder<StrategicIdentificationContext> = (conte
       : "";
 
   // Final round instruction - no more questions allowed
-  const isFinalRound = clarificationRound !== undefined && clarificationRound >= 4;
+  const isFinalRound = clarificationRound !== undefined && clarificationRound >= 2;
   const finalRoundSection = isFinalRound
     ? `\n\n⚠️ FINAL ROUND - NO MORE QUESTIONS ALLOWED ⚠️
 This is the FINAL clarification round. You MUST NOT ask any more questions.
@@ -110,9 +110,10 @@ CRITICAL RULES:
 1. **ONE strategy per item** - pick the most effective approach
 2. **Maximum 3 questions** - each question must be high-value
 3. **Specific questions** - not "Can you provide more details?" but "Where did you purchase this sofa?"
-4. **Consider user context** - if they already told you something, don't ask again
-5. **Visual estimates ALWAYS** - provide dimension/weight estimates regardless of strategy
-6. **Immediate identification** - if brand/model visible in photo, provide it immediately
+4. **NEVER repeat questions** - if a question appears in PREVIOUS ANSWERS, DO NOT ask it again or any variation of it
+5. **Consider user context** - if they already told you something, don't ask again
+6. **Visual estimates ALWAYS** - provide dimension/weight estimates regardless of strategy
+7. **Immediate identification** - if brand/model visible in photo, provide it immediately
 
 QUESTION QUALITY EXAMPLES:
 


### PR DESCRIPTION
- Reduced max clarification rounds from 5 to 3
- Final round now triggers at clarificationRound >= 2
- Added explicit rule in prompt: "NEVER repeat questions"
- Updated UI round indicator to show X/3