### PR TITLE
claude/vision-id-estimate-description-Ck8PZ

### DIFF
--- a/app/actions/identify-from-photo-v2.test.ts
+++ b/app/actions/identify-from-photo-v2.test.ts
@@ -389,6 +389,55 @@ describe("identifyProductFromPhotoV2", () => {
       expect(result.estimates.weight).toBe(60);
     });
 
+    it("includes description in estimates from visual info", async () => {
+      mockGenerateObject.mockResolvedValueOnce(
+        createMockResponse(createValidResponse())
+      );
+
+      const result = await identifyProductFromPhotoV2(
+        "https://example.com/image.jpg"
+      );
+
+      // Should include styleFamily and distinctiveFeatures
+      expect(result.estimates.description).toBe(
+        "Coffee Table. Modern. Wood top, Metal legs."
+      );
+    });
+
+    it("includes notes in description when present", async () => {
+      const responseWithNotes = createValidResponse();
+      responseWithNotes.visualEstimates.notes = "Some wear visible on surface";
+
+      mockGenerateObject.mockResolvedValueOnce(
+        createMockResponse(responseWithNotes)
+      );
+
+      const result = await identifyProductFromPhotoV2(
+        "https://example.com/image.jpg"
+      );
+
+      expect(result.estimates.description).toBe(
+        "Coffee Table. Modern. Wood top, Metal legs. Some wear visible on surface."
+      );
+    });
+
+    it("uses only itemType when no visual info available", async () => {
+      const minimalResponse = createValidResponse();
+      minimalResponse.styleFamily = null;
+      minimalResponse.distinctiveFeatures = [];
+      minimalResponse.visualEstimates.notes = null;
+
+      mockGenerateObject.mockResolvedValueOnce(
+        createMockResponse(minimalResponse)
+      );
+
+      const result = await identifyProductFromPhotoV2(
+        "https://example.com/image.jpg"
+      );
+
+      expect(result.estimates.description).toBe("Coffee Table");
+    });
+
     it("includes features and strategy in response", async () => {
       mockGenerateObject.mockResolvedValueOnce(
         createMockResponse(createValidResponse())

--- a/app/actions/identify-from-photo-v2.ts
+++ b/app/actions/identify-from-photo-v2.ts
@@ -44,6 +44,7 @@ export interface StrategicIdentificationResult {
   estimates: {
     itemType: string;
     category: string;
+    description: string;
     dimensions: { length: number | null; width: number | null; height: number | null };
     weight: number | null;
     canDisassemble: boolean | null;
@@ -166,6 +167,21 @@ export async function identifyProductFromPhotoV2(
       "Analysis complete"
     );
 
+    // Build description from available visual information
+    const descriptionParts: string[] = [];
+    if (result.styleFamily) {
+      descriptionParts.push(result.styleFamily);
+    }
+    if (result.distinctiveFeatures.length > 0) {
+      descriptionParts.push(result.distinctiveFeatures.join(", "));
+    }
+    if (result.visualEstimates.notes) {
+      descriptionParts.push(result.visualEstimates.notes);
+    }
+    const estimatesDescription = descriptionParts.length > 0
+      ? `${result.itemType}. ${descriptionParts.join(". ")}.`
+      : result.itemType;
+
     // Transform to result format
     const output: StrategicIdentificationResult = {
       identified: result.immediateIdentification
@@ -182,6 +198,7 @@ export async function identifyProductFromPhotoV2(
       estimates: {
         itemType: result.itemType,
         category: result.category,
+        description: estimatesDescription,
         dimensions: result.visualEstimates.dimensions,
         weight: result.visualEstimates.weight,
         canDisassemble: result.visualEstimates.canDisassemble,

--- a/components/inventory/add-item-dialog.tsx
+++ b/components/inventory/add-item-dialog.tsx
@@ -480,6 +480,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
     setFormData((prev) => ({
       ...prev,
       name: result.estimates.itemType,
+      description: result.estimates.description || prev.description,
       category: result.estimates.category || prev.category,
       weight: result.estimates.weight ?? prev.weight,
       length: result.estimates.dimensions.length ?? prev.length,


### PR DESCRIPTION
When the vision ID flow falls back to estimates (no product identification), now includes a description built from styleFamily, distinctiveFeatures, and visual notes. This provides more useful context for items that can't be specifically identified.