### PR TITLE
claude/improve-mobile-spacing-RoskD

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -190,7 +190,7 @@ export default function HomePage() {
   return (
     <div className="min-h-screen bg-background">
       <header className="border-b bg-background sticky top-0 z-50">
-        <div className="container mx-auto px-3 sm:px-6 py-3 sm:py-4">
+        <div className="container mx-auto px-2 sm:px-6 py-2 sm:py-4">
           <div className="flex items-center justify-between gap-2 sm:gap-4">
             <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
               <div className="rounded-xl bg-primary p-2 sm:p-2.5 shrink-0">
@@ -241,50 +241,50 @@ export default function HomePage() {
         </div>
       </header>
 
-      <main className="container mx-auto px-3 sm:px-6 py-4 sm:py-8">
-        <div className="grid gap-2 sm:gap-4 grid-cols-3 mb-4 sm:mb-8">
-          <div className="rounded-lg sm:rounded-xl border bg-card p-3 sm:p-6">
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4">
+      <main className="container mx-auto px-2 sm:px-6 py-3 sm:py-8">
+        <div className="grid gap-1.5 sm:gap-4 grid-cols-3 mb-3 sm:mb-8">
+          <div className="rounded-lg sm:rounded-xl border bg-card p-2 sm:p-6">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-1.5 sm:gap-4">
               <div className="rounded-md sm:rounded-lg bg-primary/10 p-1.5 sm:p-3 shrink-0">
                 <BoxIcon className="h-4 w-4 sm:h-6 sm:w-6 text-primary" />
               </div>
-              <div className="space-y-0.5">
-                <p className="text-xs sm:text-sm font-medium text-muted-foreground">Total Items</p>
-                <p className="text-xl sm:text-3xl font-bold">{items.length}</p>
+              <div className="space-y-0">
+                <p className="text-[10px] sm:text-sm font-medium text-muted-foreground leading-tight">Total Items</p>
+                <p className="text-lg sm:text-3xl font-bold">{items.length}</p>
               </div>
             </div>
           </div>
 
-          <div className="rounded-lg sm:rounded-xl border bg-card p-3 sm:p-6">
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4">
+          <div className="rounded-lg sm:rounded-xl border bg-card p-2 sm:p-6">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-1.5 sm:gap-4">
               <div className="rounded-md sm:rounded-lg bg-orange-500/10 p-1.5 sm:p-3 shrink-0">
                 <Truck className="h-4 w-4 sm:h-6 sm:w-6 text-orange-600" />
               </div>
-              <div className="space-y-0.5">
-                <p className="text-xs sm:text-sm font-medium text-muted-foreground">Est. Volume</p>
-                <p className="text-xl sm:text-3xl font-bold">
-                  {totalVolume.toFixed(2)} <span className="text-xs sm:text-lg text-muted-foreground">ft³</span>
+              <div className="space-y-0">
+                <p className="text-[10px] sm:text-sm font-medium text-muted-foreground leading-tight">Est. Volume</p>
+                <p className="text-lg sm:text-3xl font-bold">
+                  {totalVolume.toFixed(2)} <span className="text-[10px] sm:text-lg text-muted-foreground">ft³</span>
                 </p>
               </div>
             </div>
           </div>
 
-          <div className="rounded-lg sm:rounded-xl border bg-card p-3 sm:p-6">
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4">
+          <div className="rounded-lg sm:rounded-xl border bg-card p-2 sm:p-6">
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-1.5 sm:gap-4">
               <div className="rounded-md sm:rounded-lg bg-emerald-500/10 p-1.5 sm:p-3 shrink-0">
                 <Scale className="h-4 w-4 sm:h-6 sm:w-6 text-emerald-600" />
               </div>
-              <div className="space-y-0.5">
-                <p className="text-xs sm:text-sm font-medium text-muted-foreground">Total Weight</p>
-                <p className="text-xl sm:text-3xl font-bold">
-                  {totalWeight.toFixed(2)} <span className="text-xs sm:text-lg text-muted-foreground">lbs</span>
+              <div className="space-y-0">
+                <p className="text-[10px] sm:text-sm font-medium text-muted-foreground leading-tight">Total Weight</p>
+                <p className="text-lg sm:text-3xl font-bold">
+                  {totalWeight.toFixed(2)} <span className="text-[10px] sm:text-lg text-muted-foreground">lbs</span>
                 </p>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="mb-4 sm:mb-6">
+        <div className="mb-3 sm:mb-6">
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground" />
             <Input
@@ -296,7 +296,7 @@ export default function HomePage() {
           </div>
         </div>
 
-        <div className="sm:hidden space-y-2">
+        <div className="sm:hidden space-y-2.5">
           {isLoading ? (
             <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
               Loading your inventory...

--- a/components/inventory/add-item-dialog.tsx
+++ b/components/inventory/add-item-dialog.tsx
@@ -1010,16 +1010,16 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
           Add Item
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto sm:p-6">
         <DialogHeader>
           <DialogTitle>Add New Item</DialogTitle>
           <DialogDescription>Add an item to your moving inventory</DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
-          <div className="grid gap-4 py-4">
+          <div className="grid gap-3 sm:gap-4 py-3 sm:py-4">
             {isAnalyzingPhoto && processingStage && (
-              <div className="bg-primary/10 border border-primary/20 rounded-lg p-4 flex items-center gap-3">
-                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+              <div className="bg-primary/10 border border-primary/20 rounded-lg p-3 sm:p-4 flex items-center gap-2 sm:gap-3">
+                <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 animate-spin text-primary shrink-0" />
                 <div className="flex-1">
                   <p className="text-sm font-medium text-foreground">{processingStage}</p>
                   <p className="text-xs text-muted-foreground mt-1">
@@ -1034,26 +1034,26 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
             )}
 
             {clarificationNeeded && pendingResult?.questions && pendingResult.questions.length > 0 && (
-              <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
-                <div className="flex items-start gap-3">
-                  <HelpCircle className="h-5 w-5 text-amber-600 dark:text-amber-500 mt-0.5 flex-shrink-0" />
-                  <div className="flex-1 space-y-4">
+              <div className="bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 sm:p-4">
+                <div className="flex items-start gap-2 sm:gap-3">
+                  <HelpCircle className="h-4 w-4 sm:h-5 sm:w-5 text-amber-600 dark:text-amber-500 mt-0.5 flex-shrink-0" />
+                  <div className="flex-1 space-y-3 sm:space-y-4">
                     {/* Header with strategy info */}
                     <div>
-                      <h4 className="font-medium text-amber-900 dark:text-amber-100">
+                      <h4 className="font-medium text-sm sm:text-base text-amber-900 dark:text-amber-100">
                         Help us identify this product
                       </h4>
-                      <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
+                      <p className="text-[10px] sm:text-xs text-amber-700 dark:text-amber-400 mt-0.5 sm:mt-1">
                         Strategy: {pendingResult.strategy.approach.replace(/_/g, " ")}
                         {clarificationRound > 0 && ` (Round ${clarificationRound + 1}/3)`}
                       </p>
                     </div>
 
                     {/* Rich question inputs */}
-                    <div className="space-y-4">
+                    <div className="space-y-3 sm:space-y-4">
                       {pendingResult.questions.map((question, idx) => (
-                        <div key={idx} className="space-y-2">
-                          <Label className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                        <div key={idx} className="space-y-1.5 sm:space-y-2">
+                          <Label className="text-xs sm:text-sm font-medium text-amber-900 dark:text-amber-100 leading-snug">
                             {question.question}
                           </Label>
                           <ClarificationQuestionInput
@@ -1068,7 +1068,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                             disabled={isAnalyzingPhoto}
                           />
                           {question.rationale && (
-                            <p className="text-xs text-amber-600 dark:text-amber-400 italic">
+                            <p className="text-[10px] sm:text-xs text-amber-600 dark:text-amber-400 italic leading-relaxed">
                               {question.rationale}
                             </p>
                           )}
@@ -1077,11 +1077,11 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                     </div>
 
                     {/* Estimates preview section */}
-                    <div className="bg-white dark:bg-gray-900 border border-amber-200 dark:border-amber-700 rounded-md p-3">
-                      <h5 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+                    <div className="bg-white dark:bg-gray-900 border border-amber-200 dark:border-amber-700 rounded-md p-2.5 sm:p-3">
+                      <h5 className="text-[10px] sm:text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5 sm:mb-2">
                         Current Estimates
                       </h5>
-                      <div className="grid grid-cols-2 gap-2 text-sm">
+                      <div className="grid grid-cols-2 gap-x-2 gap-y-1 sm:gap-2 text-xs sm:text-sm">
                         <div>
                           <span className="text-gray-500 dark:text-gray-400">Type:</span>{" "}
                           <span className="text-gray-900 dark:text-gray-100">
@@ -1116,27 +1116,27 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                         )}
                       </div>
                       {pendingResult.features.length > 0 && (
-                        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                        <div className="mt-1.5 sm:mt-2 text-[10px] sm:text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
                           Features: {pendingResult.features.slice(0, 3).join(", ")}
                         </div>
                       )}
-                      <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                      <p className="text-[10px] sm:text-xs text-amber-600 dark:text-amber-400 mt-1.5 sm:mt-2">
                         These will be used if we can't identify the exact product.
                       </p>
                     </div>
 
                     {/* Additional photos section */}
                     <div className="space-y-2">
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 flex-wrap">
                         <Button
                           type="button"
                           variant="outline"
                           size="sm"
                           onClick={() => document.getElementById("clarification-photo-input")?.click()}
                           disabled={isAnalyzingPhoto}
-                          className="border-amber-300 dark:border-amber-700"
+                          className="border-amber-300 dark:border-amber-700 text-xs sm:text-sm h-8 sm:h-9"
                         >
-                          <Camera className="h-4 w-4 mr-2" />
+                          <Camera className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1.5 sm:mr-2" />
                           Add Photo
                         </Button>
                         <Input
@@ -1148,20 +1148,20 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                           className="hidden"
                         />
                         {clarificationPhotos.length > 0 && (
-                          <span className="text-sm text-amber-700 dark:text-amber-400">
+                          <span className="text-xs sm:text-sm text-amber-700 dark:text-amber-400">
                             {clarificationPhotos.length} photo{clarificationPhotos.length > 1 ? "s" : ""} added
                           </span>
                         )}
                       </div>
 
                       {clarificationPhotos.length > 0 && (
-                        <div className="grid grid-cols-3 gap-2">
+                        <div className="grid grid-cols-3 gap-1.5 sm:gap-2">
                           {clarificationPhotos.map((photo, idx) => (
                             <div key={idx} className="relative group">
                               <img
                                 src={photo || "/placeholder.svg"}
                                 alt={`Additional view ${idx + 1}`}
-                                className="w-full h-20 object-cover rounded border border-amber-200 dark:border-amber-700"
+                                className="w-full h-16 sm:h-20 object-cover rounded border border-amber-200 dark:border-amber-700"
                               />
                               <Button
                                 type="button"
@@ -1181,13 +1181,13 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                     </div>
 
                     {/* Action buttons */}
-                    <div className="flex gap-2">
+                    <div className="flex flex-col sm:flex-row gap-2">
                       <Button
                         type="button"
                         variant="outline"
                         onClick={handleSkipClarification}
                         disabled={isAnalyzingPhoto}
-                        className="flex-1 border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/30"
+                        className="flex-1 border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/30 text-xs sm:text-sm h-9 sm:h-10"
                       >
                         Skip & Use Estimates
                       </Button>
@@ -1195,11 +1195,11 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                         type="button"
                         onClick={handleClarificationSubmit}
                         disabled={isAnalyzingPhoto}
-                        className="flex-1 bg-amber-600 hover:bg-amber-700 text-white"
+                        className="flex-1 bg-amber-600 hover:bg-amber-700 text-white text-xs sm:text-sm h-9 sm:h-10"
                       >
                         {isAnalyzingPhoto ? (
                           <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            <Loader2 className="mr-1.5 sm:mr-2 h-3.5 w-3.5 sm:h-4 sm:w-4 animate-spin" />
                             Analyzing...
                           </>
                         ) : (
@@ -1212,7 +1212,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
               </div>
             )}
 
-            <div className="grid gap-2">
+            <div className="grid gap-1.5 sm:gap-2">
               <Label>Product Photo (Optional)</Label>
               {uploadedPhoto ? (
                 <div className="relative">
@@ -1268,7 +1268,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
               </p>
             </div>
 
-            <div className="grid gap-2">
+            <div className="grid gap-1.5 sm:gap-2">
               <Label htmlFor="name">Item Name *</Label>
               <div className="flex gap-2">
                 <Input
@@ -1306,7 +1306,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
               </p>
             </div>
 
-            <div className="grid gap-2">
+            <div className="grid gap-1.5 sm:gap-2">
               <Label htmlFor="description">Description</Label>
               <Textarea
                 id="description"
@@ -1316,8 +1316,8 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+              <div className="grid gap-1.5 sm:gap-2">
                 <Label htmlFor="category">Category</Label>
                 <CategorySelector
                   value={formData.category_id}
@@ -1328,7 +1328,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                 />
               </div>
 
-              <div className="grid gap-2">
+              <div className="grid gap-1.5 sm:gap-2">
                 <Label htmlFor="location">Location</Label>
                 <LocationSelector
                   value={formData.location_id}
@@ -1340,8 +1340,8 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
+            <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              <div className="grid gap-1.5 sm:gap-2">
                 <Label htmlFor="quantity">Quantity</Label>
                 <Input
                   id="quantity"
@@ -1352,7 +1352,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                 />
               </div>
 
-              <div className="grid gap-2">
+              <div className="grid gap-1.5 sm:gap-2">
                 <Label htmlFor="weight">Weight (lbs)</Label>
                 <Input
                   id="weight"
@@ -1367,8 +1367,8 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
               </div>
             </div>
 
-            <div className="grid grid-cols-3 gap-4">
-              <div className="grid gap-2">
+            <div className="grid grid-cols-3 gap-2 sm:gap-4">
+              <div className="grid gap-1.5 sm:gap-2">
                 <Label htmlFor="length">Length (in)</Label>
                 <Input
                   id="length"
@@ -1382,7 +1382,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                 />
               </div>
 
-              <div className="grid gap-2">
+              <div className="grid gap-1.5 sm:gap-2">
                 <Label htmlFor="width">Width (in)</Label>
                 <Input
                   id="width"
@@ -1396,7 +1396,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
                 />
               </div>
 
-              <div className="grid gap-2">
+              <div className="grid gap-1.5 sm:gap-2">
                 <Label htmlFor="height">Height (in)</Label>
                 <Input
                   id="height"
@@ -1411,7 +1411,7 @@ export function AddItemDialog({ onItemAdded }: AddItemDialogProps) {
               </div>
             </div>
 
-            <div className="grid gap-2">
+            <div className="grid gap-1.5 sm:gap-2">
               <Label htmlFor="notes">Notes</Label>
               <Textarea
                 id="notes"

--- a/components/inventory/item-mobile-card.tsx
+++ b/components/inventory/item-mobile-card.tsx
@@ -67,14 +67,14 @@ export function ItemMobileCard({ item, onUpdate }: ItemMobileCardProps) {
         rightActions={rightActions}
         disabled={isDeleting}
       >
-        <CardContent className="p-2.5 border rounded-xl bg-card">
+        <CardContent className="p-3 sm:p-4 border rounded-xl bg-card">
           <div>
-            <h3 className="font-semibold text-sm leading-tight mb-1">{item.name}</h3>
+            <h3 className="font-semibold text-sm leading-snug mb-0.5">{item.name}</h3>
             {item.description && (
-              <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed mb-2">{item.description}</p>
+              <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed mb-2.5">{item.description}</p>
             )}
 
-            <div className="grid grid-cols-2 gap-x-2.5 gap-y-1 mb-2">
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1.5 mb-2.5">
               <div className="flex items-center gap-1.5 text-xs">
                 <Package className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                 <span className="text-muted-foreground">Qty:</span>
@@ -100,7 +100,7 @@ export function ItemMobileCard({ item, onUpdate }: ItemMobileCardProps) {
               )}
             </div>
 
-            <div className="flex flex-wrap gap-1">
+            <div className="flex flex-wrap gap-1.5">
               <Badge variant="secondary" className="text-xs px-2 py-0.5 h-5">
                 {item.category}
               </Badge>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-1rem)] translate-x-[-50%] translate-y-[-50%] gap-3 sm:gap-4 rounded-lg border p-4 sm:p-6 shadow-lg duration-200 sm:max-w-lg',
           className,
         )}
         {...props}
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 sm:top-4 sm:right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
- Reduce dialog padding and margins on mobile (p-4 vs p-6, 0.5rem margins)
- Make form grids stack on mobile (category/location fields)
- Optimize stat cards for small screens (tighter padding, smaller text)
- Polish mobile item cards with improved spacing and visual hierarchy
- Improve clarification section layout with responsive buttons/grids
- Tighten spacing throughout for mobile-first responsive design